### PR TITLE
Added vulnerability fix to pngpread.c

### DIFF
--- a/implib/DevIL/IL/libpng/pngpread.c
+++ b/implib/DevIL/IL/libpng/pngpread.c
@@ -241,6 +241,20 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
 
       if (png_ptr->mode & PNG_AFTER_IDAT)
          png_benign_error(png_ptr, "Too many IDATs found");
+       
+      else
+      {
+          png_alloc_size_t limit = PNG_SIZE_MAX;
+           # ifdef PNG_SET_USER_LIMITS_SUPPORTED
+           if (png_ptr->user_chunk_malloc_max > 0 &&
+               png_ptr->user_chunk_malloc_max < limit)
+              limit = png_ptr->user_chunk_malloc_max;
+            # elif PNG_USER_CHUNK_MALLOC_MAX > 0
+           if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+              limit = PNG_USER_CHUNK_MALLOC_MAX;
+            # endif
+           if (png_ptr->push_length > limit)
+              png_chunk_error(png_ptr, "chunk data is too large");
    }
 
    if (chunk_name == png_IHDR)


### PR DESCRIPTION
This is for the class COSC 340 at the University of Tennessee, Knoxville. I added a vulnerability fix to pngpread.c that was added to libpng by the commit glennrp/libpng@347538e.